### PR TITLE
Add missing variable for GKE deployment

### DIFF
--- a/tap-up-and-running-bootcamp/README.md
+++ b/tap-up-and-running-bootcamp/README.md
@@ -25,6 +25,7 @@ For a better experience it's **recommended to switch to a Regional type cluster*
 With the following commands, you can provision a Regional type cluster with the [gcloud CLI](https://cloud.google.com/sdk/docs/install).
 ```
 REGION=europe-west3
+CLUSTER_ZONE="$REGION-a"
 CLUSTER_VERSION=$(gcloud container get-server-config --format="yaml(defaultClusterVersion)" --region $REGION | awk '/defaultClusterVersion:/ {print $2}')
 gcloud beta container clusters create tap --region $REGION --cluster-version $CLUSTER_VERSION --machine-type "e2-standard-4" --num-nodes "4" --node-locations $CLUSTER_ZONE --enable-pod-security-policy
 gcloud container clusters get-credentials tap --region $REGION


### PR DESCRIPTION
The variable CLUSTER_VERSION is being used in the `gcloud beta container cluster create` command is never initialized before.